### PR TITLE
fix the location_floor_plan_path route

### DIFF
--- a/app/views/floor_plans/index.json.jbuilder
+++ b/app/views/floor_plans/index.json.jbuilder
@@ -1,4 +1,4 @@
 json.array!(@floor_plans) do |floor_plan|
   json.extract! floor_plan, :title, :available_now, :available_soon, :beds, :baths, :size, :price, :deposit, :image_url, :price_url
-  json.url location_floor_plan_url(@location, floor_plan, format: json)
+  json.url location_floor_plan_url(@location, floor_plan, format: :json)
 end


### PR DESCRIPTION
@crissmancd, you mind reviewing this? 

Basically, this is all we need to do to get that json format working for the index view of the location_floor_plans_path route. As far as I can tell, floor_plan_url was just a leftover reference to an attribute that doesn't exist anymore.
