### PR TITLE
only return units for a location when @location exists

### DIFF
--- a/app/controllers/floor_plans_controller.rb
+++ b/app/controllers/floor_plans_controller.rb
@@ -9,7 +9,7 @@ class FloorPlansController < ApplicationController
   # GET /floor_plans
   # GET /floor_plans.json
   def index
-    @floor_plans = @location ? @location.floor_plans : FloorPlan.all
+    @floor_plans = @location.floor_plans
   end
 
   # GET /floor_plans/1

--- a/spec/controllers/floor_plans_controller_spec.rb
+++ b/spec/controllers/floor_plans_controller_spec.rb
@@ -22,10 +22,13 @@ describe FloorPlansController do
         http_login
       end
 
-      it "assigns all floor_plans as @floor_plans" do
-        floor_plan = @location.floor_plans.create! valid_attributes
+      it "assigns a location's floor_plans as @floor_plans" do
+        floor_plan_1 = @location.floor_plans.create! valid_attributes
+        floor_plan_2 = @location.floor_plans.create! valid_attributes
+        other_location = Location.create! "urn" => "g5-cl-6cx7rin-uluwatu", "name" => "Uluwatu"
+        other_floor_plan = other_location.floor_plans.create! "title" => "Other Floorplan"
         get :index, {location_id: @location.to_param}, valid_session
-        expect(assigns(:floor_plans)).to eq([floor_plan])
+        expect(assigns(:floor_plans)).to eq([floor_plan_1, floor_plan_2])
       end
 
       it "renders the locations index template" do


### PR DESCRIPTION
@mmitchellg5 or @bbauer or @crissmancd, you mind reviewing this?

There's a bug in the locations/floor_plans route where all floorplans for a given client show up, when you only expect to get floorplans that belong to that location.  For an example, check this out:

http://g5-cpas-6d4u4sc-madrona.herokuapp.com/locations/g5-cl-1shcl0fm-honeyman-hardware-lofts/floor_plans

You would only expect to see the two units that belong to the honeyman hardware location, yet you see all of Madrona's units for all locations. This is making a mess of the floorplans cards widget, because its getting then displaying all that extra data when it grabs this json:

http://g5-cpas-6d4u4sc-madrona.herokuapp.com/locations/g5-cl-1shcl0fm-honeyman-hardware-lofts/floor_plans.json
