### PR TITLE
Replace selenium-webdriver with poltergeist

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,8 +20,8 @@ end
 group :development, :test do
   gem "sqlite3"
   gem "rspec-rails", "~> 2.14.0"
-  gem "capybara", "~> 2.1.0"
-  gem "selenium-webdriver", "~> 2.39.0"
+  gem "capybara"
+  gem "poltergeist"
   gem "database_cleaner", "~> 1.0.1"
   gem "foreman"
   gem "fabrication"

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ group :development, :test do
   gem "foreman"
   gem "fabrication"
   gem "faker"
+  gem "pry-byebug"
 end
 
 group :production do

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,10 @@ group :development, :test do
   gem "sqlite3"
   gem "rspec-rails", "~> 2.14.0"
   gem "capybara"
-  gem "poltergeist"
+  # We need drag_by support on native elements:
+  # https://github.com/teampoltergeist/poltergeist/pull/552
+  # This should be released with v1.6.1 or v1.7.0
+  gem "poltergeist", github: "teampoltergeist/poltergeist", ref: "f826d135dd54a91f674992e2b5cab60a081e39c"
   gem "database_cleaner", "~> 1.0.1"
   gem "foreman"
   gem "fabrication"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,14 @@
+GIT
+  remote: git://github.com/teampoltergeist/poltergeist.git
+  revision: f826d135dd54a91f674992e2b5cab60a081e39c4
+  ref: f826d135dd54a91f674992e2b5cab60a081e39c
+  specs:
+    poltergeist (1.6.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      multi_json (~> 1.0)
+      websocket-driver (>= 0.2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -103,11 +114,6 @@ GEM
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     pg (0.17.1)
-    poltergeist (1.6.0)
-      capybara (~> 2.1)
-      cliver (~> 0.3.1)
-      multi_json (~> 1.0)
-      websocket-driver (>= 0.2.0)
     rack (1.5.2)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -213,7 +219,7 @@ DEPENDENCIES
   microformats2
   newrelic_rpm
   pg
-  poltergeist
+  poltergeist!
   rails (= 4.1.7)
   rails_12factor
   ranked-model

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,14 +36,13 @@ GEM
       sass (>= 3.2.0)
       thor
     builder (3.2.2)
-    capybara (2.1.0)
+    capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    childprocess (0.5.3)
-      ffi (~> 1.0, >= 1.0.11)
+    cliver (0.3.2)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     coffee-rails (4.0.1)
@@ -64,7 +63,6 @@ GEM
     fabrication (2.11.3)
     faker (1.3.0)
       i18n (~> 0.5)
-    ffi (1.9.3)
     foreman (0.66.0)
       dotenv (~> 0.7.0)
       thor (~> 0.19.1)
@@ -98,15 +96,20 @@ GEM
       json
       nokogiri
     mime-types (2.4.3)
-    mini_portile (0.6.0)
+    mini_portile (0.6.2)
     minitest (5.4.2)
     multi_json (1.10.1)
     newrelic_rpm (3.8.0.218)
-    nokogiri (1.6.3.1)
-      mini_portile (= 0.6.0)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
     pg (0.17.1)
+    poltergeist (1.6.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      multi_json (~> 1.0)
+      websocket-driver (>= 0.2.0)
     rack (1.5.2)
-    rack-test (0.6.2)
+    rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.1.7)
       actionmailer (= 4.1.7)
@@ -146,7 +149,6 @@ GEM
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
       rspec-mocks (~> 2.14.0)
-    rubyzip (1.1.3)
     sass (3.2.19)
     sass-rails (4.0.3)
       railties (>= 4.0.0, < 5.0)
@@ -156,11 +158,6 @@ GEM
     sdoc (0.4.0)
       json (~> 1.8)
       rdoc (~> 4.0, < 5.0)
-    selenium-webdriver (2.39.0)
-      childprocess (>= 0.2.5)
-      multi_json (~> 1.0)
-      rubyzip (~> 1.0)
-      websocket (~> 1.0.4)
     sprockets (2.11.0)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -190,7 +187,9 @@ GEM
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
       equalizer (~> 0.0, >= 0.0.9)
-    websocket (1.0.7)
+    websocket-driver (0.5.3)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -199,7 +198,7 @@ PLATFORMS
 
 DEPENDENCIES
   bourbon (~> 3.1.8)
-  capybara (~> 2.1.0)
+  capybara
   coffee-rails (~> 4.0.0)
   database_cleaner (~> 1.0.1)
   fabrication
@@ -214,13 +213,13 @@ DEPENDENCIES
   microformats2
   newrelic_rpm
   pg
+  poltergeist
   rails (= 4.1.7)
   rails_12factor
   ranked-model
   rspec-rails (~> 2.14.0)
   sass-rails (~> 4.0.0)
   sdoc
-  selenium-webdriver (~> 2.39.0)
   sqlite3
   turbolinks
   uglifier (>= 1.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,8 @@ GEM
       sass (>= 3.2.0)
       thor
     builder (3.2.2)
+    byebug (4.0.3)
+      columnize (= 0.9.0)
     capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -54,6 +56,7 @@ GEM
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
     cliver (0.3.2)
+    coderay (1.1.0)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     coffee-rails (4.0.1)
@@ -63,6 +66,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.7.0)
+    columnize (0.9.0)
     database_cleaner (1.0.1)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
@@ -102,6 +106,7 @@ GEM
       railties (>= 3)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
+    method_source (0.8.2)
     microformats2 (2.0.1)
       activesupport
       json
@@ -114,6 +119,13 @@ GEM
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     pg (0.17.1)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.1.0)
+      byebug (~> 4.0)
+      pry (~> 0.10)
     rack (1.5.2)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -164,6 +176,7 @@ GEM
     sdoc (0.4.0)
       json (~> 1.8)
       rdoc (~> 4.0, < 5.0)
+    slop (3.6.0)
     sprockets (2.11.0)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -220,6 +233,7 @@ DEPENDENCIES
   newrelic_rpm
   pg
   poltergeist!
+  pry-byebug
   rails (= 4.1.7)
   rails_12factor
   ranked-model

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -40,7 +40,10 @@ $(document).ready(function(){
       url = ui.item.data('update_url');
       position = ui.item.index();
       $.ajax({
-        type: 'PATCH',
+        // There are still a few browsers without proper PATCH support.
+        // Unfortunately, PhantomJS is one of them:
+        // https://github.com/ariya/phantomjs/issues/11384
+        type: 'PUT',
         url: url,
         dataType: 'json',
         data: { floor_plan: { row_order_position: position } }

--- a/spec/requests/floor_plans_spec.rb
+++ b/spec/requests/floor_plans_spec.rb
@@ -172,17 +172,16 @@ describe "Floor Plans" do
     end
   end
 
-  describe "Floor plans are drag and drop sortable" do
+  describe "Floor plans are drag and drop sortable", js: true do
     before do
+      http_login
       @location = Location.create! "urn" => "g5-cl-6cx7rin-hollywood", "name" => "Hollywood"
       @floor_plan_1 = FloorPlan.create! "location_id" => @location.id, "title" => "Unit 1"
       @floor_plan_2 = FloorPlan.create! "location_id" => @location.id, "title" => "Unit 2"
       visit location_path(@location)
     end
 
-    it "Updates database", js: true do
-      pending("Selenium doesn't play nice with HTTP basic auth")
-
+    it "Updates database" do
       expect(page).to have_content("Hollywood")
       within "#sortable" do
         floor_plan_1 = find('.floorplan:first-child')

--- a/spec/requests/floor_plans_spec.rb
+++ b/spec/requests/floor_plans_spec.rb
@@ -20,18 +20,6 @@ describe "Floor Plans" do
     click_button "Create Floor plan"
   end
 
-  def drag_and_drop(source, target)
-    builder = page.driver.browser.action
-    source = source.native
-    target = target.native
-
-    builder.click_and_hold source
-    builder.move_to        target, 1, 11
-    builder.move_to        target
-    builder.release        target
-    builder.perform
-  end
-
   describe "Floor plans index" do
     describe "with http basic auth" do
       before do
@@ -183,15 +171,13 @@ describe "Floor Plans" do
 
     it "Updates database" do
       expect(page).to have_content("Hollywood")
-      within "#sortable" do
-        floor_plan_1 = find('.floorplan:first-child')
-        floor_plan_2 = find('.floorplan:last-child')
-        expect(@floor_plan_2.row_order > @floor_plan_1.row_order).to be_true
-        floor_plan_2.drag_to(floor_plan_1)
-        drag_and_drop(floor_plan_1, floor_plan_2)
-        sleep 1
-        expect(@floor_plan_2.reload.row_order < @floor_plan_1.reload.row_order).to be_true
-      end
+      floor_plan_1 = '#sortable .floorplan:first-child'
+      floor_plan_2 = '#sortable .floorplan:last-child'
+
+      expect(@floor_plan_2.row_order > @floor_plan_1.row_order).to be_true
+      drag_and_drop_below(floor_plan_1, floor_plan_2)
+      sleep 1
+      expect(@floor_plan_2.reload.row_order < @floor_plan_1.reload.row_order).to be_true
     end
   end
 end

--- a/spec/requests/locations_spec.rb
+++ b/spec/requests/locations_spec.rb
@@ -8,6 +8,10 @@ describe "Locations" do
     click_button "Create Location"
   end
 
+  def stub_env_var(name, value)
+    stub_const('ENV', ENV.to_hash.merge(name => value))
+  end
+
   describe "Locations index" do
     describe "with http basic auth" do
       before do
@@ -39,12 +43,15 @@ describe "Locations" do
     end
 
     it "has client apps navigation" do
-      Capybara.app_host = 'http://g5-cpas-8cz7tip-clearwater.herokuapp.com'
+      stub_env_var('CMS_URL', 'https://my-cms.example.com')
+      stub_env_var('CPNS_URL', 'https://my-digits.example.com')
+      stub_env_var('CXM_URL', 'https://my-cxm.example.com')
       http_login
       visit locations_path
-      expect(page).to have_link("CMS", "http://g5-cms-8cz7tip-clearwater.herokuapp.com")
-      expect(page).to have_link("Pricing and Availability", "http://g5-cpas-8cz7tip-clearwater.herokuapp.com")
-      expect(page).to have_link("Customer Experience Management", "http://g5-cxm-8cz7tip-clearwater.herokuapp.com")
+      expect(page).to have_link("CMS", ENV['CMS_URL'])
+      expect(page).to have_link("Phone Numbers", ENV['CPNS_URL'])
+      expect(page).to have_link("Pricing and Availability", root_url)
+      expect(page).to have_link("Customer Experience Management", ENV['CXM_URL'])
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,13 @@ RSpec.configure do |config|
 
   config.include RequestAuthHelper, type: :request
   config.include ControllerAuthHelper, type: :controller
+  config.include DragAndDropHelper, type: :request
+
+  config.after(:each, js: true) do
+    # For some reason, it's not resetting back to the default driver after js specs,
+    # possibly because we're using capybara for request specs instead of feature specs
+    Capybara.use_default_driver
+  end
 
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,8 +5,15 @@ ENV["HTTP_BASIC_AUTH_PASSWORD"] ||= "password"
 
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
+
 require "capybara/rails"
 require "capybara/rspec"
+require 'capybara/poltergeist'
+Capybara.register_driver :poltergeist do |app|
+  Capybara::Poltergeist::Driver.new(app, timeout: 180)
+end
+Capybara.javascript_driver = :poltergeist
+
 require "database_cleaner"
 
 # Requires supporting ruby files with custom matchers and macros, etc,

--- a/spec/support/drag_and_drop_helper.rb
+++ b/spec/support/drag_and_drop_helper.rb
@@ -1,0 +1,30 @@
+module DragAndDropHelper
+  def position(selector)
+    coordinates = page.evaluate_script("$('#{selector}').position()")
+    OpenStruct.new(coordinates)
+  end
+
+  def height(selector)
+    page.evaluate_script("$('#{selector}').height()")
+  end
+
+  def width(selector)
+    page.evaluate_script("$('#{selector}').width()")
+  end
+
+  def drag_and_drop(source_selector, target_selector)
+    source = find(source_selector)
+    target = find(target_selector)
+    source.drag_to(target)
+  end
+
+  def drag_and_drop_below(source_selector, target_selector)
+    source_pos = position(source_selector)
+    target_pos = position(target_selector)
+
+    offset_x = 1
+    offset_y = target_pos.top - source_pos.top + height(target_selector)/2 + 1
+
+    find(source_selector).native.drag_by(offset_x, offset_y)
+  end
+end

--- a/spec/support/request_auth_helper.rb
+++ b/spec/support/request_auth_helper.rb
@@ -2,7 +2,12 @@ require "spec_helper"
 
 module RequestAuthHelper
   def http_login
-    encoded_login = ["#{ENV['HTTP_BASIC_AUTH_NAME']}:#{ENV['HTTP_BASIC_AUTH_PASSWORD']}"].pack("m*")
-    page.driver.header 'Authorization', "Basic #{encoded_login}"
+    if page.driver.browser.respond_to?(:basic_authorize) # rack-test
+      page.driver.browser.basic_authorize(ENV['HTTP_BASIC_AUTH_NAME'], ENV['HTTP_BASIC_AUTH_PASSWORD'])
+    elsif page.driver.respond_to?(:basic_authorize) # poltergeist
+      page.driver.basic_authorize(ENV['HTTP_BASIC_AUTH_NAME'], ENV['HTTP_BASIC_AUTH_PASSWORD'])
+    else # selenium-webdriver or unknown
+      raise "HTTP Basic Auth is not supported by this driver"
+    end
   end
 end


### PR DESCRIPTION
I also fixed an unrelated test that was causing order-of-execution failures in downstream tests, because it was directly modifying `Capybara.app_host` in order to force URLs to conform to expected values (now it stubs `ENV` instead, which is closer to what the original developer intended, I suspect).